### PR TITLE
CICD: Provide the correct GitHub action contexts

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/upload-artifact@v4.3.1
       with:
         name: unit-tests
-        path: $TEST_RESULTS
+        path: ${{ env.TEST_RESULTS }}
 
 # Stringer is needed because .goreleaser includes "go generate ./..."
     - name: Install stringer
@@ -204,4 +204,4 @@ jobs:
     - uses: actions/upload-artifact@v4.3.1
       with:
         name: integration-tests-${{ matrix.provider }}
-        path: $TEST_RESULTS
+        path: ${{ env.TEST_RESULTS }}


### PR DESCRIPTION
<!--
## Before submiting a pull request

Please make sure you've run the following commands from the root directory.

go vet ./...
go fmt ./...
go generate ./...
go mod tidy

## Release changelog section

Help keep the release changelog clear by pre-naming the proper section in the GitHub pull request title.

Some examples:
* CICD: Add required GHA permissions for goreleaser
* DOCS: Fixed providers with "contributor support" table
* ROUTE53: Allow R53_ALIAS records to enable target health evaluation

More examples/context can be found in the file .goreleaser.yml under the 'build' > 'changelog' key.
!-->
